### PR TITLE
Enable sending multiple subscribers in one request

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -162,6 +162,12 @@ FuelSoap.prototype.create = function(type, props, options, callback) {
 		options = null;
 	}
 
+	if (Array.isArray(props)) {
+		props.forEach(item => item.$ = { 'xsi:type': type });
+	} else {
+		props.$ = { 'xsi:type': type };
+	}
+
 	reqOptions = helpers.parseReqOptions(options);
 	body = {
 		CreateRequest: {
@@ -172,8 +178,6 @@ FuelSoap.prototype.create = function(type, props, options, callback) {
 			, Objects: props
 		}
 	};
-
-	body.CreateRequest.Objects.$ = { 'xsi:type': type };
 
 	updateQueryAllAccounts(body.CreateRequest, 'Options');
 
@@ -305,6 +309,12 @@ FuelSoap.prototype.update = function(type, props, options, callback) {
 		options = null;
 	}
 
+	if (Array.isArray(props)) {
+		props.forEach(item => item.$ = { 'xsi:type': type });
+	} else {
+		props.$ = { 'xsi:type': type };
+	}
+
 	reqOptions = helpers.parseReqOptions(options);
 	body = {
 		UpdateRequest: {
@@ -315,8 +325,6 @@ FuelSoap.prototype.update = function(type, props, options, callback) {
 			, Objects: props
 		}
 	};
-
-	body.UpdateRequest.Objects.$ = { 'xsi:type': type };
 
 	updateQueryAllAccounts(body.UpdateRequest, 'Options');
 

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -162,6 +162,12 @@ FuelSoap.prototype.create = function(type, props, options, callback) {
 		options = null;
 	}
 
+	if (Array.isArray(props)) {
+		props.forEach(item => item.$ = { 'xsi:type': type })
+	} else {
+		props.$ = { 'xsi:type': type };
+	}
+
 	reqOptions = helpers.parseReqOptions(options);
 	body = {
 		CreateRequest: {
@@ -172,8 +178,6 @@ FuelSoap.prototype.create = function(type, props, options, callback) {
 			, Objects: props
 		}
 	};
-
-	body.CreateRequest.Objects.$ = { 'xsi:type': type };
 
 	updateQueryAllAccounts(body.CreateRequest, 'Options');
 
@@ -305,6 +309,12 @@ FuelSoap.prototype.update = function(type, props, options, callback) {
 		options = null;
 	}
 
+	if (Array.isArray(props)) {
+		props.forEach(item => item.$ = { 'xsi:type': type })
+	} else {
+		props.$ = { 'xsi:type': type };
+	}
+
 	reqOptions = helpers.parseReqOptions(options);
 	body = {
 		UpdateRequest: {
@@ -315,8 +325,6 @@ FuelSoap.prototype.update = function(type, props, options, callback) {
 			, Objects: props
 		}
 	};
-
-	body.UpdateRequest.Objects.$ = { 'xsi:type': type };
 
 	updateQueryAllAccounts(body.UpdateRequest, 'Options');
 


### PR DESCRIPTION
This change allows setting the props for the subscriber object as an object or array. 
If it is set as an array, you can send multiple subscribers in one request.